### PR TITLE
Version bump and README improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+MANIFEST
+MYMETA.json
+MYMETA.yml
+Makefile
+Manta-Client-*.tar.gz
+blib/
+pm_to_blib

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Manta::Client is a Perl module for interacting with Joyent's [Manta](http://https://apidocs.joyent.com/manta/) system.
 
 ## Obtaining:
- * http://search.cpan.org/~andrewh/Manta-Client/
+ * https://metacpan.org/release/Manta-Client
  * https://github.com/joyent/Manta-Client
 
 ## Requires:

--- a/README.md
+++ b/README.md
@@ -12,5 +12,21 @@ Manta::Client is a Perl module for interacting with Joyent's [Manta](http://http
 ## Contributing
 Pull requests are welcome.
 
+## Building
+
+Generate a build for distribution using the following commands:
+```
+$ perl Makefile.PL
+$ make manifest
+$ make
+$ make dist
+...
+Created Manta-Client-${VERSION}.tar.gz
+```
+
+This tarball can be uploaded to [PAUSE](https://pause.perl.org/) to publish a new release on [CPAN](https://www.cpan.org/). Note the warning about unique version numbers on the upload page in PAUSE.
+
+Alternatively a new version may be released by tagging a commit, pushing the tag to Github, and supplying the release tarball URL to PAUSE.
+
 ## License
 Manta::Client is licensed under the MPLv2. Please see the `LICENSE` file for more details.

--- a/lib/Manta/Client.pm
+++ b/lib/Manta/Client.pm
@@ -1,4 +1,4 @@
-package Manta::Client 0.5;
+package Manta::Client 0.6;
 
 use strict;
 use warnings;


### PR DESCRIPTION
Need to make a commit to transfer ownership so I thought I'd document the "release process" at the same time.

- Add build and release instructions to README
- add a .gitignore
- bump version to 0.6

Once this PR is merged I'll tag Manta-Client-0.6 and submit the tarball link to [PAUSE](https://pause.perl.org).